### PR TITLE
UI upgrade: radio groups • checkboxes • workflow groups

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,28 +1,6 @@
-async function init() {
-  const wfDiv = document.getElementById('workflows');
-  const res = await fetch('/config');
-  const { workflows } = await res.json();
-
-  if (!Object.keys(workflows).length) {
-    wfDiv.textContent = '⚠️  No workflows defined.';
-    return;
-  }
-
-  for (const [wfKey, wf] of Object.entries(workflows)) {
-    const sec = document.createElement('section');
-    sec.innerHTML = `<h3>${wf.name}</h3>`;
-    for (const [stepKey, cmd] of Object.entries(wf.steps)) {
-      const btn = document.createElement('button');
-      btn.textContent = stepKey;
-      btn.onclick = () => run(cmd);
-      sec.appendChild(btn);
-    }
-    wfDiv.appendChild(sec);
-  }
-}
 async function run(cmd){
   const log=document.getElementById('log');
-  log.textContent=`▶ ${cmd}\n`;
+  log.textContent=`\u25B6 ${cmd}\n`;
   const resp=await fetch('/run?cmd='+encodeURIComponent(cmd));
   const reader=resp.body.getReader(), dec=new TextDecoder();
   while(true){
@@ -31,5 +9,52 @@ async function run(cmd){
     log.textContent+=dec.decode(value);
     log.scrollTop=log.scrollHeight;
   }
+}
+
+async function init(){
+  const root=document.getElementById('root');
+  const res=await fetch('/config'); const cfg=await res.json();
+  document.getElementById('title').textContent=cfg.project?.name||'Dev Dashboard';
+  if(!Object.keys(cfg.workflows).length){root.textContent='\u26A0\uFE0F No workflows defined.';return;}
+
+  // helpers
+  const executeComponents=(arr)=>arr.forEach(c=>{
+    const comp=cfg.components[c]; if(!comp) return;
+    const cmd=comp.dev||comp.command||Object.values(comp).find(v=>typeof v==='string');
+    if(cmd) run(cmd);
+  });
+
+  // render grouped workflows first
+  const rendered=new Set();
+  const renderWorkflow=(k,w)=>{
+    const sec=document.createElement('section'); sec.innerHTML=`<h3>${w.name||k}</h3>`;
+    if(w.type==='radio-group'){
+      const fs=document.createElement('fieldset'); fs.style.border='none';
+      Object.entries(w.options||{}).forEach(([optKey,opt])=>{
+        const id=`${k}-${optKey}`;
+        fs.insertAdjacentHTML('beforeend',
+          `<label><input type="radio" name="${k}" id="${id}"> ${opt.name||optKey}</label>`);
+        fs.querySelector(`#${id}`).addEventListener('change',e=>{
+          if(e.target.checked) executeComponents(opt.components||[]);
+        });
+      });
+      sec.appendChild(fs);
+    }else{ // default buttons
+      Object.entries(w.steps||{run:w.command}).forEach(([step,cmd])=>{
+        const btn=document.createElement('button');btn.textContent=step;
+        btn.onclick=()=>run(cmd); sec.appendChild(btn);
+      });
+    }
+    root.appendChild(sec); rendered.add(k);
+  };
+
+  // render groups
+  Object.entries(cfg.groups||{}).forEach(([,grp])=>{
+    const div=document.createElement('div');
+    div.innerHTML=`<h2>${grp.name}</h2>`; root.appendChild(div);
+    (grp.workflows||[]).forEach(wk=>cfg.workflows[wk]&&renderWorkflow(wk,cfg.workflows[wk]));
+  });
+  // render ungrouped leftovers
+  Object.entries(cfg.workflows).forEach(([k,w])=>!rendered.has(k)&&renderWorkflow(k,w));
 }
 init();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,19 +1,15 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8"/>
-  <title>Dev Dashboard</title>
-  <style>
-    body{font-family:sans-serif;margin:1.5rem}
-    section{margin-bottom:2rem}
-    button{margin:0.25rem 0.5rem;padding:0.4rem 0.9rem}
-    pre{background:#111;color:#0f0;padding:1rem;height:55vh;overflow:auto}
-  </style>
-</head>
-<body>
-  <h1>🚀 Dev Dashboard</h1>
-  <div id="workflows">Loading config…</div>
-  <pre id="log">Ready…</pre>
-  <script src="dashboard.js"></script>
-</body>
-</html>
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8"/><title>Dev Dashboard</title>
+<style>
+ body{font-family:sans-serif;margin:1.5rem}
+ h1{display:flex;gap:.5rem;align-items:center}
+ fieldset{border:1px solid #ccc;padding:.5rem 1rem;margin:.5rem 0}
+ button{margin:.25rem .4rem;padding:.3rem .9rem}
+ pre{background:#111;color:#0f0;padding:1rem;height:50vh;overflow:auto}
+ label{margin-right:.8rem}
+</style></head><body>
+<h1>🚀 <span id="title">Dev Dashboard</span></h1>
+<div id="root">Loading…</div>
+<pre id="log">Ready…</pre>
+<script src="dashboard.js"></script>
+</body></html>

--- a/examples/advanced/.dev-dashboard.yaml
+++ b/examples/advanced/.dev-dashboard.yaml
@@ -1,0 +1,26 @@
+project:
+  name: Example Advanced
+components:
+  ui:
+    type: checkbox
+    name: "UI Frontend"
+    dev: "echo run-ui"
+  api:
+    type: checkbox
+    name: "API Backend"
+    dev: "echo run-api"
+workflows:
+  env-mode:
+    type: radio-group
+    name: "Environment"
+    options:
+      dev:
+        name: "Dev 🖥️"
+        components: ["ui","api"]
+      prod:
+        name: "Prod 🐳"
+        components: ["ui","api"]
+workflow-groups:
+  development:
+    name: "🔨️ Development"
+    workflows: ["env-mode"]

--- a/package.json
+++ b/package.json
@@ -6,5 +6,11 @@
   "dependencies": {
     "express": "^4.19.0",
     "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "jest": "^30.0.0"
+  },
+  "scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   }
 }


### PR DESCRIPTION
## Summary
- extend server YAML loader with project, components, and workflow groups
- support radio groups and grouped workflows in the web UI
- add advanced example YAML demonstrating components
- add Jest dev dependency and a test script

## Testing
- `npm install` *(fails: 403 Forbidden – registry.npmjs.org)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea629b47c832baadf1f1e99a948d5